### PR TITLE
Move pyspark requirement to extras

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV IPYTHONDIR ./.ipython
 
 # install the extensions
 RUN pip install --upgrade jupyterlab==2.2.0
-RUN pip install jupyterlab-sparkmonitor==2.0.1
+RUN pip install jupyterlab-sparkmonitor[pyspark]==2.0.1
 RUN jupyter labextension install jupyterlab_sparkmonitor@2.0.1 --minimize=False
 RUN jupyter labextension enable jupyterlab_sparkmonitor
 RUN jupyter serverextension enable --py sparkmonitor

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ docker run -it -p 8888:8888 itsjafer/sparkmonitor
 ### Setting up the extension
 
 ```bash
+pip install jupyterlab-sparkmonitor[pyspark] # install the server/kernel extension. Remove [pyspark] part if you already have Spark installed
 jupyter labextension install jupyterlab_sparkmonitor # install the jupyterlab extension
-pip install jupyterlab-sparkmonitor # install the server/kernel extension
 jupyter serverextension enable --py sparkmonitor
 
 # set up ipython profile and add our kernel extension to it

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ setup(name='jupyterlab-sparkmonitor',
       install_requires=[
           'bs4',
           'tornado',
-          'pyspark<3.0.0',
           'jupyterlab>=2.0.0'
       ],
-      )
+      extras_require={
+          "pyspark": ["pyspark<3.0.0"]
+      }
+)


### PR DESCRIPTION
Hello.

I faced an issue with using both findspark and SparkMonitor.

I have a Spark installed to /opt folder (this is an internal bundle deployed on all of the cluster nodes), and we use findspark to properly import it.

But SparkMonitor has a pyspark dependency which leads to downloading and installing it in the current environment (like virtualenv). And because of this import https://github.com/itsjafer/jupyterlab-sparkmonitor/blob/25fc1338f10563b3fbd2598be84c2600cea479a7/sparkmonitor/kernelextension.py#L25 this local Spark will be imported and used instead of system one.

Because these Spark versions could be different, starting a session can lead to some unusual exceptions like `Py4JError: org.apache.spark.api.python.PythonUtils.isEncryptionEnabled does not exist in the JVM`

Here I propose to move spark dependency to extras. So if user need pyspark to be installed along with SparkMonitor, he could use `jupyterlab-sparkmonitor[pyspark]`, but it will be skipped by default.

This can break backward compatibility.