### PR TITLE
Fix issue with logging FileHandler in unsupported random writes file system

### DIFF
--- a/sparkmonitor/kernelextension.py
+++ b/sparkmonitor/kernelextension.py
@@ -158,13 +158,10 @@ def load_ipython_extension(ipython):
 
     logger = logging.getLogger('sparkmonitorkernel')
 
-    if os.environ.get("SPARKMONITOR_LOG_LEVEL") is not None:
-        log_level = os.environ.get("SPARKMONITOR_LOG_LEVEL", "INFO")
-        if log_level.lower() not in ["debug", "info", "warning", "error", "critical"]:
-            log_level = "INFO"
-    else:
-        logger.setLevel(log_level)
-
+    log_level = os.environ.get("SPARKMONITOR_LOG_LEVEL", "INFO")
+    if log_level.upper() not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+        log_level = "INFO"
+    logger.setLevel(log_level)
     logger.propagate = False
 
     if os.environ.get("SPARKMONITOR_LOG_HANDLER", "file").lower() == "file":

--- a/sparkmonitor/kernelextension.py
+++ b/sparkmonitor/kernelextension.py
@@ -158,7 +158,7 @@ def load_ipython_extension(ipython):
 
     logger = logging.getLogger('sparkmonitorkernel')
 
-    log_level = os.environ.get("SPARKMONITOR_LOG_LEVEL", "INFO")
+    log_level = os.environ.get("SPARKMONITOR_LOG_LEVEL", "WARNING")
     if log_level.upper() not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
         log_level = "INFO"
     logger.setLevel(log_level)

--- a/sparkmonitor/kernelextension.py
+++ b/sparkmonitor/kernelextension.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """SparkMonitor IPython Kernel Extension
+
 Receives data from listener and forwards to frontend.
 Adds a configuration object to users namespace.
 """
@@ -8,7 +9,6 @@ from __future__ import unicode_literals
 
 import logging
 import os
-import sys
 import socket
 from threading import Thread
 
@@ -37,6 +37,7 @@ class ScalaMonitor:
 
     def __init__(self, ipython):
         """Constructor
+
         ipython is the instance of ZMQInteractiveShell
         """
         self.ipython = ipython
@@ -58,6 +59,7 @@ class ScalaMonitor:
 
     def handle_comm_message(self, msg):
         """Handle message received from frontend
+
         Does nothing for now as this only works if kernel is not busy.
         """
         logger.info('COMM MESSAGE:  \n %s', str(msg))
@@ -101,6 +103,7 @@ class SocketThread(Thread):
 
     def run(self):
         """Overrides Thread.run
+
         Creates a socket and waits(blocking) for connections
         When a connection is closed, goes back into waiting.
         """
@@ -146,34 +149,23 @@ class SocketThread(Thread):
 
 def load_ipython_extension(ipython):
     """Entrypoint, called when the extension is loaded.
+
     ipython is the InteractiveShell instance
     """
     global ip, monitor  # For Debugging
 
     global logger
-
     logger = logging.getLogger('sparkmonitorkernel')
-
-    if os.environ.get("SPARKMONITOR_LOG_LEVEL") is not None:
-        log_level = os.environ.get("SPARKMONITOR_LOG_LEVEL", "INFO")
-        if log_level.lower() not in ["debug", "info", "warning", "error", "critical"]:
-            log_level = "INFO"
-    else:
-        logger.setLevel(log_level)
-
+    logger.setLevel(logging.DEBUG)
     logger.propagate = False
-
-    if os.environ.get("SPARKMONITOR_LOG_HANDLER", "file").lower() == "file":
-        handler = logging.FileHandler('sparkmonitor_kernelextension.log', mode='w')
-    else:
-        handler = logging.StreamHandler(sys.stdout)
-
-    handler.setLevel(log_level)
+    # For debugging this module - Writes logs to a file
+    fh = logging.FileHandler('sparkmonitor_kernelextension.log', mode='w')
+    fh.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
         '%(levelname)s:  %(asctime)s - %(name)s - %(process)d - %(processName)s - \
-        %(thread)d - %(threadName)s - %(message)s')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
+        %(thread)d - %(threadName)s\n %(message)s \n')
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)
 
     if ipykernel_imported:
         if not isinstance(ipython, zmqshell.ZMQInteractiveShell):
@@ -211,6 +203,7 @@ def unload_ipython_extension(ipython):
 
 def configure(conf):
     """Configures the provided conf object.
+
     Sets the Java Classpath and listener jar file path to "conf".
     Also sets an environment variable for ports for communication
     with scala listener.


### PR DESCRIPTION
In this PR, we are adding some env vars to control logging settings.

I needed it because the FileHandler causes an error with file systems that does not support random writes (e.g. dbfs).

- `SPARKMONITOR_LOG_LEVEL`: Logging Level.
  - DEBUG, INFO (default value), WARNING, ERROR, CRITICAL 
- `SPARKMONITOR_LOG_HANDLER`: Use FileHandler or StreamHandler
  - "file" (default value) use FileHandler('sparkmonitor_kernelextension.log', mode='w')
  - "anything else" use StreamHandler(sys.stdout)